### PR TITLE
Twilio node client as a peer dependency 

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,11 +19,11 @@ Implementing the `TwilioModule` from this package you gain access to Twilio clie
 ## Instalation
 
 ```bash
-$ npm install --save nestjs-twilio
+$ npm install --save twilio nestjs-twilio
 ```
 
 ```bash
-$ yarn add nestjs-twilio
+$ yarn add twilio nestjs-twilio
 ```
 
 ## Getting Started

--- a/package.json
+++ b/package.json
@@ -39,9 +39,6 @@
     "clean:test": "rimraf coverage",
     "prepare": "yarn build:dist"
   },
-  "dependencies": {
-    "twilio": "3.49.1"
-  },
   "devDependencies": {
     "@nestjs/common": "7.4.4",
     "@nestjs/core": "7.4.4",
@@ -63,6 +60,12 @@
     "rimraf": "^3.0.2",
     "rxjs": "6.6.3",
     "ts-jest": "26.3.0",
-    "typescript": "4.0.2"
+    "typescript": "4.0.2",
+    "twilio": "3.49.1"
+  },
+  "peerDependencies": {
+    "twilio": "<= 3.49.1",
+    "@nestjs/common": "<= 7.4.4",
+    "@nestjs/core": "<= 7.4.4"
   }
 }


### PR DESCRIPTION
 ## What

I move Twilio node client to be used as a peer dependency adding @nestjs/common and @nestjs/core as well.

## Why

Related to this issue #6